### PR TITLE
Update the link to SRTM tiles

### DIFF
--- a/R/elevation.R
+++ b/R/elevation.R
@@ -19,7 +19,7 @@ elevation_3s <- function(lon, lat, path, ...) {
 
 	if (!file.exists(tiffilename)) {
 		if (!file.exists(zipfilename)) {
-			theurl <- paste("http://srtm.csi.cgiar.org/SRT-ZIP/SRTM_V41/SRTM_Data_GeoTiff/", f, ".zip", sep="")
+			theurl <- paste("https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/", f, ".zip", sep="")
 			test <- try (.download(theurl, zipfilename, ...) , silent=TRUE)
 			if (class(test) == "try-error") {
 				theurl <- paste("http://droppr.org/srtm/v4.1/6_5x5_TIFs/", f, ".zip", sep="")


### PR DESCRIPTION
`geodata::elevation_3s()` function currently points to non-existing URLs:

``` r
elev <- geodata::elevation_3s(lon = 56.42, lat = 58.07, path = ".")
#> Warning in utils::download.file(url = aurl, destfile = fn, method = "auto", :
#> cannot open URL 'https://srtm.csi.cgiar.org/SRT-ZIP/SRTM_V41/SRTM_Data_GeoTiff/
#> srtm_48_01.zip': HTTP status was '404 Not Found'
#> Warning in utils::download.file(url = aurl, destfile = fn, method = "auto", :
#> downloaded length 0 != reported length 150
#> Warning in utils::download.file(url = aurl, destfile = fn, method = "auto", :
#> cannot open URL 'http://droppr.org/srtm/v4.1/6_5x5_TIFs/srtm_48_01.zip': HTTP
#> status was '404 Not Found'
#> Warning in utils::download.file(url = aurl, destfile = fn, method = "auto", :
#> URL 'ftp://xftp.jrc.it/pub/srtmV4/tiff/srtm_48_01.zip': status was 'Couldn't
#> resolve host name'
#> Error in utils::download.file(url = aurl, destfile = fn, method = "auto", : cannot open URL 'ftp://xftp.jrc.it/pub/srtmV4/tiff/srtm_48_01.zip'
```

I updated the URL with what is currently working on [CGIAR](https://srtm.csi.cgiar.org). The fallback URLs are also failing in the current version, but I don't know what to replace them with.