### PR TITLE
Identify missing download files

### DIFF
--- a/R/gadm.R
+++ b/R/gadm.R
@@ -31,7 +31,7 @@
 		exists <- try(.check_gadm(filename, gversion), silent=TRUE)
 		if (!inherits(exists, "try-error")) {
 			if (!exists) {
-				message("this file does not exist")
+				message(f, " - this file does not exist") 
 				return(NULL)
 			}
 		}


### PR DESCRIPTION
`gadm` reports when a file doesn't exist, but doesn't tell you which file is
missing. This little tweak will report the name of the missing file to the
user, so they can deal with it.

This is an issue when downloading a long list of countries (i.e., Asia),
for which some of the codes from `country_codes` do not correspond to a
download file (.e.g, Hong Kong, Macao, Western Cyprus).
