### PR TITLE
.getCountryISO(): warning if length(countries) > 1

### DIFF
--- a/R/countries.R
+++ b/R/countries.R
@@ -15,6 +15,8 @@ country_codes <- function(query = NULL) {
 
 .getCountryISO <- function(country) {
 
+	if (length(country) > 1) warning("'country' has >1 elements, only the first element will be used")
+
 	country <- toupper(trimws(country[1]))
 	cs <- country_codes()
 	cs <- sapply(cs, toupper)


### PR DESCRIPTION
...in which case only the 1st one is used, all others silently ignored. Addressing issue #46 