### PR TITLE
add pkgdown website

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Encoding: UTF-8
 Maintainer: Robert J. Hijmans <r.hijmans@gmail.com>
 Description: Functions for downloading of geographic data for use in spatial analysis and mapping. The package facilitates access to climate, crops, elevation, land use, soil, species occurrence, accessibility, administrative boundaries and other data.
 License: GPL (>=3)
+URL: https://rspatial.github.io/geodata/
 BugReports: https://github.com/rspatial/geodata/issues/
 Authors@R: c(
 	person("Robert J.", "Hijmans", role=c("cre", "aut"),  

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # geodata
 
 <!-- badges: start -->
+[![CRAN status](https://www.r-pkg.org/badges/version/geodata)](https://cran.r-project.org/package=geodata)
 <!-- badges: end -->
 
 **geodata** is an R package for downloading geographic data.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,1 +1,3 @@
 url: https://rspatial.github.io/geodata/
+template:
+  bootstrap: 5

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,1 @@
+url: https://rspatial.github.io/geodata/


### PR DESCRIPTION
Hey @rhijmans! Could you add `pkgdown` website to this package? I think it will improve accessibility from the user perspective.

1. Repository > Settings > Pages > Set `gh-pages` in Branch
2. Repository > The gear icon on the right in the About section > Check "Use your GitHub Pages website"
3. I also think you can add some topics describing the repository, e.g. `r`, `spatial-data`, `geospatial`, `geodata`, `raster-data`, `vector-data`.